### PR TITLE
fix snapshots loading for wrong devices - use updated UC response

### DIFF
--- a/src/external-api/network-types.ts
+++ b/src/external-api/network-types.ts
@@ -118,6 +118,7 @@ const UniconfigSnapshotsOutputValidator = t.type({
         t.type({
           name: t.string,
           'creation-time': t.string,
+          nodes: t.array(t.string),
         }),
       ),
     }),


### PR DESCRIPTION
For this to work, you need a new version UC, currently deployed on `.7` machine.