### PR TITLE
handle correct values to be sent to the client when querying device mountParams

### DIFF
--- a/src/schema/device.ts
+++ b/src/schema/device.ts
@@ -84,7 +84,7 @@ export const Device = objectType({
     t.string('mountParameters', {
       resolve: async (root) => {
         if (root.mountParameters != null) {
-          return String(root.mountParameters);
+          return JSON.stringify(root.mountParameters);
         }
         return null;
       },


### PR DESCRIPTION
Use JSON.stringify because when using String constructor the value sent to the client in case of JSON is going to be [Object object]