### PR TITLE
change 'has' api call; add name to interfaces

### DIFF
--- a/src/external-api/topology-discovery.ts
+++ b/src/external-api/topology-discovery.ts
@@ -1,12 +1,12 @@
 import { sendGetRequest, sendPatchRequest, sendPostRequest } from './helpers';
 import {
-  decodeHasOutput,
+  decodeHasAndInterfacesOutput,
   decodeLinksAndDevicesOutput,
   decodeTopologyCommonNodesOutput,
   decodeTopologyDiffOutput,
   decodeUpdateCoordinatesOutput,
   decodeVersionsOutput,
-  HasOutput,
+  HasAndInterfacesOutput,
   LinksAndDevicesOutput,
   TopologyCommonNodesOutput,
   TopologyDiffOutput,
@@ -48,9 +48,9 @@ async function getLinksAndDevices(baseURL: string): Promise<LinksAndDevicesOutpu
   return data;
 }
 
-async function getHas(baseURL: string): Promise<HasOutput> {
-  const json = await sendGetRequest([baseURL, '/has']);
-  const data = decodeHasOutput(json);
+async function getHasAndInterfaces(baseURL: string): Promise<HasAndInterfacesOutput> {
+  const json = await sendGetRequest([baseURL, '/has-and-interfaces']);
+  const data = decodeHasAndInterfacesOutput(json);
   return data;
 }
 
@@ -74,7 +74,7 @@ const topologyDiscoveryAPI = {
   getTopologyDiff,
   getCommonNodes,
   getLinksAndDevices,
-  getHas,
+  getHasAndInterfaces,
   updateCoordinates,
 };
 

--- a/src/external-api/topology-network-types.ts
+++ b/src/external-api/topology-network-types.ts
@@ -51,7 +51,7 @@ const Device = t.intersection([
 
 export type ArangoDevice = t.TypeOf<typeof Device>;
 
-const EdgeStatus = t.union([t.literal('ok'), t.literal('unknown')]);
+const Status = t.union([t.literal('ok'), t.literal('unknown')]);
 const Edge = t.type({
   _id: t.string,
   _key: t.string,
@@ -62,7 +62,7 @@ const Edge = t.type({
 const EdgeWithStatus = t.intersection([
   Edge,
   t.type({
-    status: EdgeStatus,
+    status: Status,
   }),
 ]);
 
@@ -136,12 +136,22 @@ export function decodeLinksAndDevicesOutput(value: unknown): LinksAndDevicesOutp
   return extractResult(LinksAndDevicesOutputValidator.decode(value));
 }
 
-const HasOutputValidator = t.array(EdgeWithStatus);
+const InterfaceWithStatus = t.intersection([
+  Interface,
+  t.type({
+    status: Status,
+  }),
+]);
 
-export type HasOutput = t.TypeOf<typeof HasOutputValidator>;
+const HasAndInterfacesOutputValidator = t.type({
+  has: t.array(EdgeWithStatus),
+  interfaces: t.array(InterfaceWithStatus),
+});
 
-export function decodeHasOutput(value: unknown): HasOutput {
-  return extractResult(HasOutputValidator.decode(value));
+export type HasAndInterfacesOutput = t.TypeOf<typeof HasAndInterfacesOutputValidator>;
+
+export function decodeHasAndInterfacesOutput(value: unknown): HasAndInterfacesOutput {
+  return extractResult(HasAndInterfacesOutputValidator.decode(value));
 }
 
 const UpdateCoordinatesOutputValidator = t.type({

--- a/src/schema/api.graphql
+++ b/src/schema/api.graphql
@@ -301,6 +301,7 @@ input GraphNodeCoordinatesInput {
 
 type GraphNodeInterface {
   id: String!
+  name: String!
   status: GraphEdgeStatus!
 }
 

--- a/src/schema/nexus-typegen.ts
+++ b/src/schema/nexus-typegen.ts
@@ -313,6 +313,7 @@ export interface NexusGenObjects {
   GraphNodeInterface: {
     // root type
     id: string; // String!
+    name: string; // String!
     status: NexusGenEnums['GraphEdgeStatus']; // GraphEdgeStatus!
   };
   GraphVersionEdge: {
@@ -660,6 +661,7 @@ export interface NexusGenFieldTypes {
   GraphNodeInterface: {
     // field return type
     id: string; // String!
+    name: string; // String!
     status: NexusGenEnums['GraphEdgeStatus']; // GraphEdgeStatus!
   };
   GraphVersionEdge: {
@@ -1067,6 +1069,7 @@ export interface NexusGenFieldTypeNames {
   GraphNodeInterface: {
     // field return type name
     id: 'String';
+    name: 'String';
     status: 'GraphEdgeStatus';
   };
   GraphVersionEdge: {


### PR DESCRIPTION
Use new API call instead of `has` which adds new field `interfaces`. We use it to add `name` to display in the UI.