### PR TITLE
Change executed task query

### DIFF
--- a/src/external-api/conductor-network-types.ts
+++ b/src/external-api/conductor-network-types.ts
@@ -118,6 +118,7 @@ const ExecutedWorkflowTask = t.type({
   taskType: optional(t.string),
   status: optional(ExecutedWorkflowTaskStatus),
   inputData: optional(t.record(t.string, t.unknown)),
+  outputData: optional(t.record(t.string, t.unknown)),
   referenceTaskName: optional(t.string),
   retryCount: optional(t.number),
   seq: optional(t.number),
@@ -163,7 +164,7 @@ const ExecutedWorkflow = t.type({
   updatedBy: optional(t.string),
   status: ExecutedWorkflowStatus,
   endTime: optional(t.number),
-  workflowId: optional(t.string),
+  workflowId: t.string,
   parentWorkflowId: optional(t.string),
   parentWorkflowTaskId: optional(t.string),
   tasks: optional(t.array(ExecutedWorkflowTask)),
@@ -263,4 +264,8 @@ export function decodeBulkRetryOutput(value: unknown): BulkOperationOutput {
 
 export function decodeBulkRestartOutput(value: unknown): BulkOperationOutput {
   return extractResult(BulkOperation.decode(value));
+}
+
+export function decodeExecutedWorkflowTaskDetailOutput(value: unknown): ApiExecutedWorkflowTask {
+  return extractResult(ExecutedWorkflowTask.decode(value));
 }

--- a/src/external-api/conductor.ts
+++ b/src/external-api/conductor.ts
@@ -186,7 +186,7 @@ async function executeWorkflowByName(
       baseURL,
       `workflow/${name}?${version == null ? '' : `version=${version}`}${
         correlationId == null ? '' : `&correlationId=${correlationId}`
-      }&priority=${priority}`,
+      }&priority=${priority == null ? 0 : priority}`,
     ],
     inputParameters,
   );

--- a/src/external-api/conductor.ts
+++ b/src/external-api/conductor.ts
@@ -121,6 +121,8 @@ async function getExecutedWorkflowDetail(
   const json = await sendGetRequest([baseURL, `workflow/${workflowId}${query}`]);
   const data = decodeExecutedWorkflowDetailOutput(json);
 
+  console.log(data.tasks);
+
   return data;
 }
 
@@ -181,15 +183,24 @@ async function executeWorkflowByName(
   baseURL: string,
   { name, inputParameters, correlationId, version, priority }: ExecuteWorkflowByNameInput,
 ): Promise<string> {
-  const executedWorkflowId = await sendPostRequest(
-    [baseURL, `workflow/${name}?version=${version}&correlationId=${correlationId}&priority=${priority}`],
-    inputParameters,
-  );
+  try {
+    const executedWorkflowId = await sendPostRequest(
+      [
+        baseURL,
+        `workflow/${name}?${version == null ? '' : `version=${version}`}${
+          correlationId == null ? '' : `&correlationId=${correlationId}`
+        }&priority=${priority}`,
+      ],
+      inputParameters,
+    );
 
-  if (executedWorkflowId != null && typeof executedWorkflowId === 'string') {
-    return executedWorkflowId;
-  } else {
-    throw new Error('We could not execute the workflow');
+    if (executedWorkflowId != null && typeof executedWorkflowId === 'string') {
+      return executedWorkflowId;
+    } else {
+      throw new Error('We could not execute the workflow');
+    }
+  } catch (err: any) {
+    throw new Error(err);
   }
 }
 

--- a/src/external-api/conductor.ts
+++ b/src/external-api/conductor.ts
@@ -173,7 +173,7 @@ type ExecuteWorkflowByNameInput = {
   name: string;
   inputParameters: Record<string, unknown>;
   correlationId?: string | null;
-  version?: string | null;
+  version?: number | null;
   priority?: number | null;
 };
 

--- a/src/external-api/conductor.ts
+++ b/src/external-api/conductor.ts
@@ -15,6 +15,8 @@ import {
   TaskDefinitionsOutput,
   decodeTaskDefinitionsOutput,
   decodeBulkTerminateOutput,
+  decodeExecutedWorkflowTaskDetailOutput,
+  ApiExecutedWorkflowTask,
 } from './conductor-network-types';
 import { sendDeleteRequest, sendGetRequest, sendPostRequest, sendPutRequest } from './helpers';
 
@@ -171,7 +173,7 @@ type ExecuteWorkflowByNameInput = {
   name: string;
   inputParameters: Record<string, unknown>;
   correlationId?: string | null;
-  version?: number | null;
+  version?: string | null;
   priority?: number | null;
 };
 
@@ -197,6 +199,12 @@ async function getTaskDefinitions(baseURL: string): Promise<TaskDefinitionsOutpu
   return data;
 }
 
+async function getExecutedWorkflowTaskDetail(baseURL: string, taskId: string): Promise<ApiExecutedWorkflowTask> {
+  const json = await sendGetRequest([baseURL, `/tasks/${taskId}`]);
+  const data = decodeExecutedWorkflowTaskDetailOutput(json);
+  return data;
+}
+
 const conductorAPI = {
   getWorkflowMetadata,
   getWorkflowDetail,
@@ -219,6 +227,7 @@ const conductorAPI = {
   executeNewWorkflow,
   executeWorkflowByName,
   getTaskDefinitions,
+  getExecutedWorkflowTaskDetail,
 };
 
 export type ConductorAPI = typeof conductorAPI;

--- a/src/external-api/conductor.ts
+++ b/src/external-api/conductor.ts
@@ -121,8 +121,6 @@ async function getExecutedWorkflowDetail(
   const json = await sendGetRequest([baseURL, `workflow/${workflowId}${query}`]);
   const data = decodeExecutedWorkflowDetailOutput(json);
 
-  console.log(data.tasks);
-
   return data;
 }
 
@@ -183,24 +181,20 @@ async function executeWorkflowByName(
   baseURL: string,
   { name, inputParameters, correlationId, version, priority }: ExecuteWorkflowByNameInput,
 ): Promise<string> {
-  try {
-    const executedWorkflowId = await sendPostRequest(
-      [
-        baseURL,
-        `workflow/${name}?${version == null ? '' : `version=${version}`}${
-          correlationId == null ? '' : `&correlationId=${correlationId}`
-        }&priority=${priority}`,
-      ],
-      inputParameters,
-    );
+  const executedWorkflowId = await sendPostRequest(
+    [
+      baseURL,
+      `workflow/${name}?${version == null ? '' : `version=${version}`}${
+        correlationId == null ? '' : `&correlationId=${correlationId}`
+      }&priority=${priority}`,
+    ],
+    inputParameters,
+  );
 
-    if (executedWorkflowId != null && typeof executedWorkflowId === 'string') {
-      return executedWorkflowId;
-    } else {
-      throw new Error('We could not execute the workflow');
-    }
-  } catch (err: any) {
-    throw new Error(err);
+  if (executedWorkflowId != null && typeof executedWorkflowId === 'string') {
+    return executedWorkflowId;
+  } else {
+    throw new Error('We could not execute the workflow');
   }
 }
 

--- a/src/external-api/helpers.ts
+++ b/src/external-api/helpers.ts
@@ -89,10 +89,13 @@ async function apiFetch(path: APIPath, options: RequestInit): Promise<unknown> {
     return response;
   }
 
-  const json = JSON.parse(text);
-  logResponse(requestId, json);
-
-  return json;
+  try {
+    const json = JSON.parse(text);
+    return json;
+  } catch (e) {
+    logResponse(requestId, text);
+    return text;
+  }
 }
 
 export async function sendGetRequest(path: APIPath, cookie?: string): Promise<unknown> {

--- a/src/helpers/workflow.helpers.ts
+++ b/src/helpers/workflow.helpers.ts
@@ -112,7 +112,7 @@ function extractSubworkflowsFromTasks(task: ExecutedWorkflowTask): SubWorkflow |
 }
 
 type SubworkflowDetail = {
-  taskReferenceName: string;
+  referenceTaskName: string;
   workflowDetail: Workflow;
   executedWorkflowDetail: ExecutedWorkflow;
 };
@@ -137,7 +137,7 @@ async function getSubworklowsDetail(subWorkflow: SubWorkflow): Promise<Subworkfl
   };
 
   return {
-    taskReferenceName: referenceTaskName,
+    referenceTaskName,
     workflowDetail: workflowDetailWithId,
     executedWorkflowDetail: executedWorkflowDetailWithId,
   };

--- a/src/schema/api.graphql
+++ b/src/schema/api.graphql
@@ -330,7 +330,7 @@ input ExecuteWorkflowByName {
   inputParameters: String!
   priority: Int
   workflowName: String!
-  workflowVersion: String
+  workflowVersion: Int
 }
 
 type ExecutedWorkflow implements Node {
@@ -407,6 +407,7 @@ type ExecutedWorkflowTask implements Node {
   outputData: String
   pollCount: Int
   reasonForIncompletion: String
+  referenceTaskName: String
   retried: Boolean
   retryCount: Int
   scheduledTime: String
@@ -417,7 +418,6 @@ type ExecutedWorkflowTask implements Node {
   taskDefName: String
   taskDefinition: String
   taskId: String
-  taskReferenceName: String
   taskType: String
   updateTime: String
   version: Int
@@ -776,7 +776,7 @@ input StartWorkflowRequestInput {
 
 type SubWorkflow {
   executedWorkflowDetail: ExecutedWorkflow!
-  taskReferenceName: String!
+  referenceTaskName: String!
   workflowDetail: Workflow!
 }
 

--- a/src/schema/api.graphql
+++ b/src/schema/api.graphql
@@ -330,10 +330,11 @@ input ExecuteWorkflowByName {
   inputParameters: String!
   priority: Int
   workflowName: String!
-  workflowVersion: Int
+  workflowVersion: String
 }
 
 type ExecutedWorkflow implements Node {
+  correlationId: String
   createdAt: String
   createdBy: String
   endTime: String
@@ -353,7 +354,7 @@ type ExecutedWorkflow implements Node {
   variables: String
   version: Int
   workflowDefinition: Workflow
-  workflowId: String
+  workflowId: String!
   workflowName: String
   workflowVersion: Int
 }
@@ -396,13 +397,20 @@ enum ExecutedWorkflowStatus {
 }
 
 type ExecutedWorkflowTask implements Node {
+  callbackAfterSeconds: Int
   endTime: String
   executed: Boolean
+  externalInputPayloadStoragePath: String
+  externalOutputPayloadStoragePath: String
   id: ID!
+  inputData: String
+  outputData: String
+  pollCount: Int
   reasonForIncompletion: String
   retried: Boolean
   retryCount: Int
   scheduledTime: String
+  seq: Int
   startTime: String
   status: ExecutedWorkflowTaskStatus
   subWorkflowId: String

--- a/src/schema/global-types.ts
+++ b/src/schema/global-types.ts
@@ -130,6 +130,15 @@ export const NodeQuery = extendType({
 
             return { ...schedule, id: args.id, __typename: 'Schedule' };
           }
+          case 'ExecutedWorkflowTask': {
+            const id = fromGraphId('ExecutedWorkflowTask', args.id);
+            const task = await conductorAPI.getExecutedWorkflowTaskDetail(config.conductorApiURL, id);
+            if (task == null) {
+              return null;
+            }
+
+            return { ...task, id: args.id, __typename: 'ExecutedWorkflowTask' };
+          }
           /* eslint-enable */
           default:
             return null;

--- a/src/schema/nexus-typegen.ts
+++ b/src/schema/nexus-typegen.ts
@@ -150,7 +150,7 @@ export interface NexusGenInputs {
     inputParameters: string; // String!
     priority?: number | null; // Int
     workflowName: string; // String!
-    workflowVersion?: string | null; // String
+    workflowVersion?: number | null; // Int
   };
   ExecutedWorkflowFilterInput: {
     // input type
@@ -661,7 +661,7 @@ export interface NexusGenObjects {
   SubWorkflow: {
     // root type
     executedWorkflowDetail: NexusGenRootTypes['ExecutedWorkflow']; // ExecutedWorkflow!
-    taskReferenceName: string; // String!
+    referenceTaskName: string; // String!
     workflowDetail: NexusGenRootTypes['Workflow']; // Workflow!
   };
   Subscription: {};
@@ -1013,6 +1013,7 @@ export interface NexusGenFieldTypes {
     outputData: string | null; // String
     pollCount: number | null; // Int
     reasonForIncompletion: string | null; // String
+    referenceTaskName: string | null; // String
     retried: boolean | null; // Boolean
     retryCount: number | null; // Int
     scheduledTime: string | null; // String
@@ -1023,7 +1024,6 @@ export interface NexusGenFieldTypes {
     taskDefName: string | null; // String
     taskDefinition: string | null; // String
     taskId: string | null; // String
-    taskReferenceName: string | null; // String
     taskType: string | null; // String
     updateTime: string | null; // String
     version: number | null; // Int
@@ -1266,7 +1266,7 @@ export interface NexusGenFieldTypes {
   SubWorkflow: {
     // field return type
     executedWorkflowDetail: NexusGenRootTypes['ExecutedWorkflow']; // ExecutedWorkflow!
-    taskReferenceName: string; // String!
+    referenceTaskName: string; // String!
     workflowDetail: NexusGenRootTypes['Workflow']; // Workflow!
   };
   Subscription: {
@@ -1660,6 +1660,7 @@ export interface NexusGenFieldTypeNames {
     outputData: 'String';
     pollCount: 'Int';
     reasonForIncompletion: 'String';
+    referenceTaskName: 'String';
     retried: 'Boolean';
     retryCount: 'Int';
     scheduledTime: 'String';
@@ -1670,7 +1671,6 @@ export interface NexusGenFieldTypeNames {
     taskDefName: 'String';
     taskDefinition: 'String';
     taskId: 'String';
-    taskReferenceName: 'String';
     taskType: 'String';
     updateTime: 'String';
     version: 'Int';
@@ -1913,7 +1913,7 @@ export interface NexusGenFieldTypeNames {
   SubWorkflow: {
     // field return type name
     executedWorkflowDetail: 'ExecutedWorkflow';
-    taskReferenceName: 'String';
+    referenceTaskName: 'String';
     workflowDetail: 'Workflow';
   };
   Subscription: {

--- a/src/schema/nexus-typegen.ts
+++ b/src/schema/nexus-typegen.ts
@@ -150,7 +150,7 @@ export interface NexusGenInputs {
     inputParameters: string; // String!
     priority?: number | null; // Int
     workflowName: string; // String!
-    workflowVersion?: number | null; // Int
+    workflowVersion?: string | null; // String
   };
   ExecutedWorkflowFilterInput: {
     // input type
@@ -966,6 +966,7 @@ export interface NexusGenFieldTypes {
   };
   ExecutedWorkflow: {
     // field return type
+    correlationId: string | null; // String
     createdAt: string | null; // String
     createdBy: string | null; // String
     endTime: string | null; // String
@@ -985,7 +986,7 @@ export interface NexusGenFieldTypes {
     variables: string | null; // String
     version: number | null; // Int
     workflowDefinition: NexusGenRootTypes['Workflow'] | null; // Workflow
-    workflowId: string | null; // String
+    workflowId: string; // String!
     workflowName: string | null; // String
     workflowVersion: number | null; // Int
   };
@@ -1002,13 +1003,20 @@ export interface NexusGenFieldTypes {
   };
   ExecutedWorkflowTask: {
     // field return type
+    callbackAfterSeconds: number | null; // Int
     endTime: string | null; // String
     executed: boolean | null; // Boolean
+    externalInputPayloadStoragePath: string | null; // String
+    externalOutputPayloadStoragePath: string | null; // String
     id: string; // ID!
+    inputData: string | null; // String
+    outputData: string | null; // String
+    pollCount: number | null; // Int
     reasonForIncompletion: string | null; // String
     retried: boolean | null; // Boolean
     retryCount: number | null; // Int
     scheduledTime: string | null; // String
+    seq: number | null; // Int
     startTime: string | null; // String
     status: NexusGenEnums['ExecutedWorkflowTaskStatus'] | null; // ExecutedWorkflowTaskStatus
     subWorkflowId: string | null; // String
@@ -1605,6 +1613,7 @@ export interface NexusGenFieldTypeNames {
   };
   ExecutedWorkflow: {
     // field return type name
+    correlationId: 'String';
     createdAt: 'String';
     createdBy: 'String';
     endTime: 'String';
@@ -1641,13 +1650,20 @@ export interface NexusGenFieldTypeNames {
   };
   ExecutedWorkflowTask: {
     // field return type name
+    callbackAfterSeconds: 'Int';
     endTime: 'String';
     executed: 'Boolean';
+    externalInputPayloadStoragePath: 'String';
+    externalOutputPayloadStoragePath: 'String';
     id: 'ID';
+    inputData: 'String';
+    outputData: 'String';
+    pollCount: 'Int';
     reasonForIncompletion: 'String';
     retried: 'Boolean';
     retryCount: 'Int';
     scheduledTime: 'String';
+    seq: 'Int';
     startTime: 'String';
     status: 'ExecutedWorkflowTaskStatus';
     subWorkflowId: 'String';

--- a/src/schema/task.ts
+++ b/src/schema/task.ts
@@ -76,6 +76,13 @@ export const ExecutedWorkflowTask = objectType({
     t.string('reasonForIncompletion');
     t.string('taskDefinition', { resolve: (task) => JSON.stringify(task.taskDefinition) });
     t.string('subWorkflowId');
+    t.string('inputData', { resolve: (task) => JSON.stringify(task.inputData) });
+    t.string('outputData', { resolve: (task) => JSON.stringify(task.outputData) });
+    t.string('externalOutputPayloadStoragePath');
+    t.string('externalInputPayloadStoragePath');
+    t.int('callbackAfterSeconds');
+    t.int('seq');
+    t.int('pollCount');
   },
 });
 

--- a/src/schema/task.ts
+++ b/src/schema/task.ts
@@ -53,7 +53,7 @@ export const ExecutedWorkflowTask = objectType({
       resolve: (executedWorkflowTask) => toGraphId('ExecutedWorkflowTask', executedWorkflowTask.taskId ?? uuid()),
     });
     t.string('taskType');
-    t.string('taskReferenceName');
+    t.string('referenceTaskName');
     t.field('status', { type: ExecutedWorkflowTaskStatus });
     t.int('retryCount');
     t.string('startTime', {

--- a/src/schema/workflow.ts
+++ b/src/schema/workflow.ts
@@ -726,7 +726,7 @@ export const ExecuteWorkflowByName = mutationField('executeWorkflowByName', {
     const workflowId = await conductorAPI.executeWorkflowByName(config.conductorApiURL, {
       inputParameters: json,
       name: workflowName,
-      version: String(workflowVersion),
+      version: workflowVersion,
       correlationId,
       priority,
     });


### PR DESCRIPTION
- refactored graphId from uuid to executed workflowId (this property is mandatory and never null or undefined)
- bugfixing
> - taskReferenceName -> referenceTaskName (previously because of naming was returning empty value)
> - handle correct URL parsing when sent empty values as params
> - changed value in executed workflow detail subscription, because was not loading tasks when restarted workflow
