### PR TITLE
added sorting to taskDefinitions query

### DIFF
--- a/src/schema/api.graphql
+++ b/src/schema/api.graphql
@@ -938,6 +938,7 @@ type Query {
     filter: FilterTaskDefinitionsInput
     first: Int
     last: Int
+    orderBy: TasksOrderByInput
   ): TaskDefinitionConnection!
   topology(filter: FilterTopologyInput): Topology
   topologyCommonNodes(nodes: [String!]!): TopologyCommonNodes
@@ -1093,6 +1094,15 @@ enum SortPollsDirection {
   desc
 }
 
+enum SortTasksBy {
+  name
+  responseTimeoutSeconds
+  retryCount
+  retryLogic
+  timeoutPolicy
+  timeoutSeconds
+}
+
 enum SortWorkflowsBy {
   name
 }
@@ -1178,6 +1188,11 @@ enum TaskTimeoutPolicy {
   ALERT_ONLY
   RETRY
   TIME_OUT_WF
+}
+
+input TasksOrderByInput {
+  direction: SortDirection!
+  sortKey: SortTasksBy!
 }
 
 input TerminateWorkflowInput {

--- a/src/schema/nexus-typegen.ts
+++ b/src/schema/nexus-typegen.ts
@@ -361,6 +361,11 @@ export interface NexusGenInputs {
     type?: string | null; // String
     workflowTaskType?: Array<NexusGenEnums['WorkflowTaskType'] | null> | null; // [WorkflowTaskType]
   };
+  TasksOrderByInput: {
+    // input type
+    direction: NexusGenEnums['SortDirection']; // SortDirection!
+    sortKey: NexusGenEnums['SortTasksBy']; // SortTasksBy!
+  };
   TerminateWorkflowInput: {
     // input type
     reason?: string | null; // String
@@ -471,6 +476,7 @@ export interface NexusGenEnums {
   SortExecutedWorkflowsDirection: 'asc' | 'desc';
   SortPollsBy: 'lastPollTime' | 'queueName' | 'workerId';
   SortPollsDirection: 'asc' | 'desc';
+  SortTasksBy: 'name' | 'responseTimeoutSeconds' | 'retryCount' | 'retryLogic' | 'timeoutPolicy' | 'timeoutSeconds';
   SortWorkflowsBy: 'name';
   TaskTimeoutPolicy: 'ALERT_ONLY' | 'RETRY' | 'TIME_OUT_WF';
   TimeoutPolicy: 'ALERT_ONLY' | 'TIME_OUT_WF';
@@ -2922,6 +2928,7 @@ export interface NexusGenArgTypes {
       filter?: NexusGenInputs['FilterTaskDefinitionsInput'] | null; // FilterTaskDefinitionsInput
       first?: number | null; // Int
       last?: number | null; // Int
+      orderBy?: NexusGenInputs['TasksOrderByInput'] | null; // TasksOrderByInput
     };
     topology: {
       // args


### PR DESCRIPTION
moved sorting of task definitions from UI to the inventory server, use with `tasks-graphql-sorting` from frinx-frontend