### PR TITLE
remove possibility to change values of createdAt or updatedAt values

### DIFF
--- a/src/schema/api.graphql
+++ b/src/schema/api.graphql
@@ -1350,8 +1350,6 @@ type WorkflowConnection {
 }
 
 input WorkflowDefinitionInput {
-  createTime: Int
-  createdAt: Int
   createdBy: String
   description: String
   inputParameters: [String]
@@ -1365,8 +1363,6 @@ input WorkflowDefinitionInput {
   tasks: [TaskInput!]!
   timeoutPolicy: TimeoutPolicy
   timeoutSeconds: Int!
-  updateTime: Int
-  updatedAt: Int
   updatedBy: String
   variables: String
   version: Int

--- a/src/schema/api.graphql
+++ b/src/schema/api.graphql
@@ -1379,7 +1379,6 @@ type WorkflowEdge {
 
 input WorkflowInput {
   accessPolicy: Record
-  createdAt: String
   createdBy: String
   description: String
   failureWorkflow: String
@@ -1394,7 +1393,6 @@ input WorkflowInput {
   tasks: String!
   timeoutPolicy: TimeoutPolicy
   timeoutSeconds: Int!
-  updatedAt: String
   updatedBy: String
   variables: Record
   version: Int

--- a/src/schema/nexus-typegen.ts
+++ b/src/schema/nexus-typegen.ts
@@ -409,8 +409,6 @@ export interface NexusGenInputs {
   };
   WorkflowDefinitionInput: {
     // input type
-    createTime?: number | null; // Int
-    createdAt?: number | null; // Int
     createdBy?: string | null; // String
     description?: string | null; // String
     inputParameters?: Array<string | null> | null; // [String]
@@ -424,8 +422,6 @@ export interface NexusGenInputs {
     tasks: NexusGenInputs['TaskInput'][]; // [TaskInput!]!
     timeoutPolicy?: NexusGenEnums['TimeoutPolicy'] | null; // TimeoutPolicy
     timeoutSeconds: number; // Int!
-    updateTime?: number | null; // Int
-    updatedAt?: number | null; // Int
     updatedBy?: string | null; // String
     variables?: string | null; // String
     version?: number | null; // Int

--- a/src/schema/nexus-typegen.ts
+++ b/src/schema/nexus-typegen.ts
@@ -433,7 +433,6 @@ export interface NexusGenInputs {
   WorkflowInput: {
     // input type
     accessPolicy?: NexusGenScalars['Record'] | null; // Record
-    createdAt?: string | null; // String
     createdBy?: string | null; // String
     description?: string | null; // String
     failureWorkflow?: string | null; // String
@@ -448,7 +447,6 @@ export interface NexusGenInputs {
     tasks: string; // String!
     timeoutPolicy?: NexusGenEnums['TimeoutPolicy'] | null; // TimeoutPolicy
     timeoutSeconds: number; // Int!
-    updatedAt?: string | null; // String
     updatedBy?: string | null; // String
     variables?: NexusGenScalars['Record'] | null; // Record
     version?: number | null; // Int

--- a/src/schema/workflow.ts
+++ b/src/schema/workflow.ts
@@ -223,10 +223,6 @@ export const WorkflowDefinitionInput = inputObjectType({
     t.field('timeoutPolicy', {
       type: TimeoutPolicy,
     });
-    t.int('createdAt');
-    t.int('updatedAt');
-    t.int('createTime');
-    t.int('updateTime');
     t.string('createdBy');
     t.string('updatedBy');
   },

--- a/src/schema/workflow.ts
+++ b/src/schema/workflow.ts
@@ -514,8 +514,6 @@ const WorkflowInput = inputObjectType({
     });
     t.string('createdBy');
     t.string('updatedBy');
-    t.string('createdAt');
-    t.string('updatedAt');
     t.record('accessPolicy');
     t.string('failureWorkflow');
     t.boolean('workflowStatusListenerEnabled');
@@ -591,6 +589,8 @@ export const CreateWorkflowMutation = extendType({
           tasks: parsedTasks,
           version: workflow.version || undefined,
           description: workflow.description || undefined,
+          createTime: Date.now(),
+          updateTime: Date.now(),
         };
 
         await conductorAPI.createWorkflow(config.conductorApiURL, apiWorkflow);
@@ -645,8 +645,7 @@ export const UpdateWorkflowMutation = extendType({
           description: workflow.description || undefined,
           restartable: workflow.restartable || undefined,
           outputParameters: outputParameters || undefined,
-          createTime: workflow.createdAt ? Date.parse(workflow.createdAt) : undefined,
-          updateTime: workflow.updatedAt ? Date.parse(workflow.updatedAt) : undefined,
+          updateTime: Date.now(),
           createdBy: workflow.createdBy || undefined,
           updatedBy: workflow.updatedBy || undefined,
           schemaVersion: workflow.schemaVersion || undefined,


### PR DESCRIPTION
Changes made:
- removed createdAt / updatedAt properties from workflowInput
- now any thrid party is not able to change value of createdAt or updatedAt, they are changed solely in inventory server