### PR TITLE
make performance monitor env optional

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -33,7 +33,7 @@ type TopologyConfigEnabled = {
   topologyEnabled: true;
   topologyDiscoveryURL: string;
   topologyDiscoveryGraphqlURL: string;
-  performanceMonitoringGraphqlURL: string;
+  performanceMonitoringGraphqlURL: string | null;
 };
 
 type TopologyConfigDisabled = {
@@ -66,9 +66,9 @@ function getTopologyConfig(): TopologyConfig {
     };
   }
 
-  if (!topologyDiscoveryURL || !topologyDiscoveryGraphqlURL || !performanceMonitoringGraphqlURL) {
+  if (!topologyDiscoveryURL || !topologyDiscoveryGraphqlURL) {
     throw new Error(
-      'Not all mandatory topology discovery url (TOPOLOGY_DISCOVERY_API_URL, TOPOLOGY_DISCOVERY_GRAPHQL_API_URL, PERFORMANCE_MONITORING_GRAPHQL_API_URL) were found.',
+      'Not all mandatory topology discovery url (TOPOLOGY_DISCOVERY_API_URL, TOPOLOGY_DISCOVERY_GRAPHQL_API_URL) were found.',
     );
   }
 

--- a/src/external-api/performance-monitoring-graphql.ts
+++ b/src/external-api/performance-monitoring-graphql.ts
@@ -62,6 +62,11 @@ function getPerformanceMonitoringAPI() {
       return undefined;
     }
   }
+
+  if (!config.performanceMonitoringGraphqlURL) {
+    return undefined;
+  }
+
   const client = new GraphQLClient(config.performanceMonitoringGraphqlURL);
 
   async function getDeviceCpuUsage(deviceName: string): Promise<CurrentCpuUsageQuery> {


### PR DESCRIPTION
HOW TO TEST:

you should be able to start inventory server without PERFORMANCE_MONITORING_GRAPHQL_API_URL env variable being set