### PR TITLE
make country arg optional

### DIFF
--- a/src/schema/location.ts
+++ b/src/schema/location.ts
@@ -153,7 +153,7 @@ export const AddLocationMutation = extendType({
           data: {
             tenantId,
             name: input.name,
-            country: countryName,
+            country: countryName ?? undefined,
             latitude: input.coordinates.latitude.toString(),
             longitude: input.coordinates.latitude.toString(),
           },


### PR DESCRIPTION
check addLocation inputs:
```
{
  "input": {
    "name": "slovakia",
    "coordinates": {
      "latitude": 1,
      "longitude": 1
    }
  }
}
```

```
{
  "input": {
    "name": "slovakia2",
    "coordinates": {
      "latitude": 1,
      "longitude": 1
    },
    "countryId": "Q291bnRyeTpTVks="
  }
}