### PR TITLE
FD-683 supress uc errors

### DIFF
--- a/src/schema/device.ts
+++ b/src/schema/device.ts
@@ -116,9 +116,14 @@ export const Device = objectType({
     t.nonNull.boolean('isInstalled', {
       resolve: async (root, _, { prisma }) => {
         const { uniconfigZoneId } = root;
-        const uniconfigURL = await getUniconfigURL(prisma, uniconfigZoneId);
-        const isInstalled = await getCachedDeviceInstallStatus(uniconfigURL, root.name);
-        return isInstalled;
+        try {
+          const uniconfigURL = await getUniconfigURL(prisma, uniconfigZoneId);
+          const isInstalled = await getCachedDeviceInstallStatus(uniconfigURL, root.name);
+          return isInstalled;
+        } catch {
+          // FD-683 supress isInstalled error when something is wrong with uniconfig
+          return false;
+        }
       },
     });
     t.nonNull.field('zone', {


### PR DESCRIPTION
HOW TO TEST:

try to change `UNICONFIG_API_URL` in ui-dev-proxy to some none existing ur (you can just add some non existing suffix to it like `test`).

when you run, you should get success result (not error):
```
query Devices {
  devices {
    edges {
      node {
        id
        name
        isInstalled
      }
    }
  }
}
```